### PR TITLE
New proxy option and improvements

### DIFF
--- a/app/components/Head.js
+++ b/app/components/Head.js
@@ -11,12 +11,25 @@ class Head extends React.Component {
     this.state = { 'proxyRunning': ipcRenderer.sendSync('proxyIsRunning') };
   }
 
+  componentDidMount() {
+    ipcRenderer.on('proxyStarted', (event, message) => {
+      this.setState({ 'proxyRunning': true });
+    });
+
+    ipcRenderer.on('proxyStopped', (event, message) => {
+      this.setState({ 'proxyRunning': false });
+    });
+  }
+
+  componentWillUnmount() {
+    ipcRenderer.removeAllListeners('proxyStarted');
+    ipcRenderer.removeAllListeners('proxyStopped');
+  }
+
   toggleProxy(e) {
     if(ipcRenderer.sendSync('proxyIsRunning')) {
-      this.setState({ 'proxyRunning': false });
       ipcRenderer.send('proxyStop');
     } else {
-      this.setState({ 'proxyRunning': true });
       ipcRenderer.send('proxyStart');
     }
   }

--- a/app/pages/Settings.js
+++ b/app/pages/Settings.js
@@ -47,27 +47,22 @@ class Settings extends React.Component {
             <Form.Field>
               <Input label='Files Path' action={<Button content='Change' onClick={this.openDialog.bind(this)} />} value={this.state.filesPath} readOnly fluid />
             </Form.Field>
-            <Form.Field>
-              <SettingsItem
-                section='App'
-                setting='debug'
-                Input={<Checkbox />}
-              />
-            </Form.Field>
-          </Form>
-        </Segment>
-        <Header as='h4' attached='top'>
-          Proxy
-        </Header>
-        <Segment attached>
-          <Form>
-            <Form.Field>
-              <SettingsItem
-                section='Proxy'
-                setting='autoStart'
-                Input={<Checkbox />}
-              />
-            </Form.Field>
+            <Form.Group widths='equal'>
+              <Form.Field>
+                <SettingsItem
+                  section='App'
+                  setting='debug'
+                  Input={<Checkbox />}
+                />
+              </Form.Field>
+              <Form.Field>
+                <SettingsItem
+                  section='Proxy'
+                  setting='autoStart'
+                  Input={<Checkbox />}
+                />
+              </Form.Field>
+            </Form.Group>
           </Form>
         </Segment>
         <Header as='h4' attached='top'>

--- a/app/pages/Settings.js
+++ b/app/pages/Settings.js
@@ -57,6 +57,20 @@ class Settings extends React.Component {
           </Form>
         </Segment>
         <Header as='h4' attached='top'>
+          Proxy
+        </Header>
+        <Segment attached>
+          <Form>
+            <Form.Field>
+              <SettingsItem
+                section='Proxy'
+                setting='autoStart'
+                Input={<Checkbox />}
+              />
+            </Form.Field>
+          </Form>
+        </Segment>
+        <Header as='h4' attached='top'>
           Plugins
         </Header>
         <Segment attached>
@@ -126,9 +140,9 @@ class SettingsItem extends React.Component {
       case 'Checkbox':
         return <Checkbox {...this.Input.props} label={this.getLabel()} checked={this.state.value} onChange={this.changeSetting.bind(this)} />
       case 'Select':
-        return <Select {...this.Input.props} value={this.state.value} onChange={this.changeSetting.bind(this)} />
+        return <Select {...this.Input.props} label={this.getLabel()} value={this.state.value} onChange={this.changeSetting.bind(this)} />
       default:
-        return <Input {...this.Input.props} value={this.state.value} onChange={this.changeSetting.bind(this)} />
+        return <Input {...this.Input.props} label={this.getLabel()} value={this.state.value} onChange={this.changeSetting.bind(this)} />
     }
   }
 

--- a/app/proxy/SWProxy.js
+++ b/app/proxy/SWProxy.js
@@ -93,6 +93,7 @@ class SWProxy extends EventEmitter {
       this.proxy.web(req, resp, { target: req.url, prependPath: false });
     }).listen(port, () => {
       this.log({ type: 'info', source: 'proxy', message: `Now listening on port ${port}` });
+      win.webContents.send('proxyStarted');
     });
 
     this.httpServer.on('error', (e) => {
@@ -125,7 +126,9 @@ class SWProxy extends EventEmitter {
   stop() {
     this.proxy.close();
     this.httpServer.close();
-    this.log({ type: 'info', source: 'proxy', message: `Proxy stopped` })
+
+    win.webContents.send('proxyStopped');
+    this.log({ type: 'info', source: 'proxy', message: `Proxy stopped` });
   }
 
   getInterfaces() {
@@ -155,7 +158,8 @@ class SWProxy extends EventEmitter {
 
     entry.date = new Date().toLocaleTimeString();
     this.logEntries.push(entry);
-    this.emit('logupdated', entry);
+
+    win.webContents.send('logupdated', entry)
   }
 
   getLogEntries() {


### PR DESCRIPTION
New option: Start proxy automatically
mainWindow is now availabe globally to easily get it later on
Make sure that window is initialized before config loads
Saved ID of mainWindow for future purposes in the renderer process
Only update UI if proxy really started or stopped (button)
Fixed automatic setting labels for input and select