### PR TITLE
Fix raid logging bug

### DIFF
--- a/app/plugins/run-logger.js
+++ b/app/plugins/run-logger.js
@@ -215,29 +215,29 @@ module.exports = {
 
     const reward = resp.reward ? resp.reward : {};
 
-    if (winLost === 1 && !resp.reward.crate) {
-      entry.drop = `${resp.battle_reward_list.find(value => value.wizard_id === resp.wizard_info.wizard_id).reward_list[0].item_quantity} Mana`;
-    } else if (winLost > 1 && winLost !== 4) {
-      if (reward.crate.runecraft_info) {
-        const item = {};
-        item.info = {};
-        item.info.craft_type = reward.crate.runecraft_info.craft_type;
-        item.info.craft_type_id = reward.crate.runecraft_info.craft_type_id;
-        entry = this.getItemRift(item, entry);
-      }
-      if (reward.crate.rune) {
-        entry = this.getItemRift(reward.crate.rune, entry);
-      }
-      if (reward.crate.unit_info && reward.crate.unit_info.unit_master_id > 0) {
-        entry.drop = `${gMapping.getMonsterName(reward.crate.unit_info.unit_master_id)} ${reward.crate.unit_info.class}`;
-      }
-      if (!entry.drop && resp.reward.crate) {
-        entry.drop = this.getItem(reward.crate);
+    if (resp.win_lose === 1 ) {
+      if (!reward.crate) {
+        entry.drop = `${resp.battle_reward_list.find(value => value.wizard_id === resp.wizard_info.wizard_id).reward_list[0].item_quantity} Mana`;
+      } else {
+        if (reward.crate.runecraft_info) {
+          const item = {};
+          item.info = {};
+          item.info.craft_type = reward.crate.runecraft_info.craft_type;
+          item.info.craft_type_id = reward.crate.runecraft_info.craft_type_id;
+          entry = this.getItemRift(item, entry);
+        } else if (reward.crate.rune) {
+          entry = this.getItemRift(reward.crate.rune, entry);
+        } else if (reward.crate.unit_info && reward.crate.unit_info.unit_master_id > 0) {
+          entry.drop = `${gMapping.getMonsterName(reward.crate.unit_info.unit_master_id)} ${reward.crate.unit_info.class}`;
+        } else if (!entry.drop && resp.reward.crate) {
+          entry.drop = this.getItem(reward.crate);
+        } else {
+          entry.drop = 'unknown';
+        }
       }
     } else {
-      entry.drop = 'unknown';
+      entry.drop = 'none';
     }
-
 
     if (resp.unit_list && resp.unit_list.length > 0) {
       resp.unit_list.forEach((unit, i) => {

--- a/app/plugins/run-logger.js
+++ b/app/plugins/run-logger.js
@@ -215,25 +215,25 @@ module.exports = {
 
     const reward = resp.reward ? resp.reward : {};
 
-    if (resp.win_lose === 1 ) {
+    if (resp.win_lose === 1) {
       if (!reward.crate) {
         entry.drop = `${resp.battle_reward_list.find(value => value.wizard_id === resp.wizard_info.wizard_id).reward_list[0].item_quantity} Mana`;
+      } else if (reward.crate.runecraft_info) {
+        const item = {
+          info: {
+            craft_type: reward.crate.runecraft_info.craft_type,
+            craft_type_id: reward.crate.runecraft_info.craft_type_id
+          }
+        };
+        entry = this.getItemRift(item, entry);
+      } else if (reward.crate.rune) {
+        entry = this.getItemRift(reward.crate.rune, entry);
+      } else if (reward.crate.unit_info && reward.crate.unit_info.unit_master_id > 0) {
+        entry.drop = `${gMapping.getMonsterName(reward.crate.unit_info.unit_master_id)} ${reward.crate.unit_info.class}`;
+      } else if (!entry.drop && resp.reward.crate) {
+        entry.drop = this.getItem(reward.crate);
       } else {
-        if (reward.crate.runecraft_info) {
-          const item = {};
-          item.info = {};
-          item.info.craft_type = reward.crate.runecraft_info.craft_type;
-          item.info.craft_type_id = reward.crate.runecraft_info.craft_type_id;
-          entry = this.getItemRift(item, entry);
-        } else if (reward.crate.rune) {
-          entry = this.getItemRift(reward.crate.rune, entry);
-        } else if (reward.crate.unit_info && reward.crate.unit_info.unit_master_id > 0) {
-          entry.drop = `${gMapping.getMonsterName(reward.crate.unit_info.unit_master_id)} ${reward.crate.unit_info.class}`;
-        } else if (!entry.drop && resp.reward.crate) {
-          entry.drop = this.getItem(reward.crate);
-        } else {
-          entry.drop = 'unknown';
-        }
+        entry.drop = 'unknown';
       }
     } else {
       entry.drop = 'none';


### PR DESCRIPTION
This resolves issue #100 

A few minor fixes are involved as part of this:

-  The conditional check for win/lose uses the original value since the variable winLose is a string
-  The existence of reward.crate is now checked before processing is performed on it
-  If the raid fails, record 'none' for the drop instead of 'unknown'

Steps I took to reproduce:

-  Took a terrible team into r5 to fail and see the reported error

Steps I took to verify:

-  Took a terrible team into r5 to fail and see no error
-  logged message: 2017-11-03 23:45,,Did not kill,,,,,none,,,,,,,,,,,,,,,,,,