### PR TITLE
Update to electron 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "1.8.2",
+    "electron": "2.0.9",
     "electron-builder": "^20.15.3",
     "electron-rebuild": "^1.7.3",
     "eslint": "^4.19.1",


### PR DESCRIPTION
This fixes the white screens on Raspberry Pi 3 B+ when running via `npm start`.

I was able to use the proxy after hard-coding the correct decryption key in app/proxy/smon_decryptor.js.

I won't be testing this change on any other platforms.