### PR TITLE
Fixed rift raid result mapping

### DIFF
--- a/app/plugins/live-sync.js
+++ b/app/plugins/live-sync.js
@@ -159,8 +159,8 @@ module.exports = {
           const reward = resp.battle_reward_list[rewardID].reward_list[0] || {};
 
           if (reward.item_master_type === 27) {
-            const craftInfo = resp.reward.crate.runecraft_info;
-            this.saveAction(proxy, wizardId, resp.tvalue, 'new_craft', { craft: craftInfo });
+            const changestone = resp.reward.crate.changestones[0] || {};
+            this.saveAction(proxy, wizardId, resp.tvalue, 'new_craft', { craft: changestone });
             break;
           }
         }

--- a/app/plugins/run-logger.js
+++ b/app/plugins/run-logger.js
@@ -252,17 +252,32 @@ module.exports = {
     entry.date = dateFormat(new Date(), 'yyyy-mm-dd HH:MM');
     entry.result = winLost;
 
+    if (resp.clear_time) {
+      const seconds =
+        Math.floor((resp.clear_time.current_time / 1000) % 60) < 10
+          ? `0${Math.floor((resp.clear_time.current_time / 1000) % 60)}`
+          : Math.floor((resp.clear_time.current_time / 1000) % 60);
+      const time = [Math.floor(resp.clear_time.current_time / 1000 / 60), seconds];
+      entry.time = `${time[0]}:${time[1]}`;
+    }
+
     const reward = resp.reward ? resp.reward : {};
 
     if (resp.win_lose === 1) {
       if (!reward.crate) {
-        entry.drop = `${resp.battle_reward_list.find(value => value.wizard_id === resp.wizard_info.wizard_id).reward_list[0].item_quantity} Mana`;
-      } else if (reward.crate.runecraft_info) {
+        const reward = resp.battle_reward_list.find(value => value.wizard_id === resp.wizard_info.wizard_id).reward_list[0];
+        if (reward.item_master_id === 6) {
+          entry.drop = `Shapeshifting stones x${reward.item_quantity}`;
+        } else {
+          entry.drop = `${reward.item_quantity} Mana`;
+        }
+      } else if (reward.crate.changestones) {
         const item = {
           info: {
-            craft_type: reward.crate.runecraft_info.craft_type,
-            craft_type_id: reward.crate.runecraft_info.craft_type_id
-          }
+            craft_type: reward.crate.changestones[0].craft_type,
+            craft_type_id: reward.crate.changestones[0].craft_type_id
+          },
+          sell_value: reward.crate.changestones[0].sell_value
         };
         entry = this.getItemRift(item, entry);
       } else if (reward.crate.rune) {
@@ -283,6 +298,7 @@ module.exports = {
         entry[`team${i + 1}`] = gMapping.getMonsterName(unit.unit_master_id);
       });
     }
+
     const headers = [
       'date',
       'dungeon',


### PR DESCRIPTION
Updated live sync and run logger plugins to use current rift raid battle result structure. 

For live sync, I was getting SW Optmizer crashes when live sync feature loads rift raid result file. The json was something like that:

```
{
  "wizard_id": xxx,
  "timestamp": 1549578489,
  "action": "new_craft",
  "type": "raw"
}
```
Since there is no runecraft_info inside resp.reward.crate anymore, there was no grindstone/gem data in json file, and it crashed SW Optimizer.

For run logger, this may fix #190, but some csv columns of the rift raid result file were left blank because it seems the data is not obtainable anymore in current json structure (e.g. dungeon level).

Also, fixed Shapeshifting Stones that were being shown as Mana Stones.

I hope it helps :)