### PR TITLE
External plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module.exports = {
 }
 ```
 
-The [NodeJS 10 standard library](https://nodejs.org/dist/latest-v10.x/docs/api/) is available to use within your plugin. To receive game events, you must subscribe to events from `proxy`. See the See the [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) for the two options to receive events - every game event, or specific events. `proxy` is an [EventEmitter](https://nodejs.org/docs/latest-v10.x/api/events.html). `config` is the configuration for the full SW-Exporter application. You can access your specific plugin's configuration like this: `config.Config.Plugins[<pluginName>]`. When in doubt, browse through the [prepackaged plugins](https://github.com/Xzandro/sw-exporter/tree/external-plugins/app/plugins) for examples.
+The [NodeJS 10 standard library](https://nodejs.org/dist/latest-v10.x/docs/api/) is available to use within your plugin. To receive game events, you must subscribe to events from `proxy`. See the [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) for the two options to receive events - every game event, or specific events. `proxy` is an [EventEmitter](https://nodejs.org/docs/latest-v10.x/api/events.html). `config` is the configuration for the full SW-Exporter application. You can access your specific plugin's configuration like this: `config.Config.Plugins[<pluginName>]`. When in doubt, browse through the [prepackaged plugins](https://github.com/Xzandro/sw-exporter/tree/external-plugins/app/plugins) for examples.
 
 ### Single Javascript File
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,61 @@
 # Summoner's War Exporter
 
-This tool will parse intercepted data from Summoner's War and extract information on the monsters and runes of the user. It works just like SWProxy and the focus was to write a smooth proxy, that runs fast and to fix common glitches with SWPRoxy (SW starting problems, errors on event pages etc.). You can even turn on Summoners War Exporter for normal surfing, because it doesnt really influence other pages much.
+This tool will parse intercepted data from Summoner's War and extract information on the monsters and runes of the user. It works just like SWProxy and the focus was to write a smooth proxy, that runs fast and to fix common glitches with SWProxy (SW starting problems, errors on event pages etc.). You can even turn on Summoners War Exporter for normal surfing, because it doesnt really influence other pages much.
 
 ![swex](http://i.imgur.com/NQGNNaF.png)
 
 ## Downloading and Installation
+
 1. Go to the [latest release](https://github.com/Xzandro/sw-exporter/releases/latest).
 2. Download the package for your computer OS. Windows also offers a portable version which does not require installation.
 3. Run it!
 
 Further instructions are available in the Help section of Summoner's War Exporter
 
-## Setting up for Development
+## Developing Plugins
+
+You can create your own plugins that will receive in-game events and data. What you do with that data is up to your imagination. There are two options for creating a plugin - a single javascript file, or a full NPM package. Your plugin must export the following by default:
+
+```javascript
+module.exports = {
+  defaultConfig: {
+    enabled: true,
+    // any other options for your plugin here
+    // Must be simple value types - string, number, boolean
+  },
+  defaultConfigDetails: {
+    // Provides some customization for the form input. Match keys from defaultConfig
+  },
+  pluginName: <string>,
+  pluginDescription: <string>,
+  init: function(proxy, config)
+}
+```
+
+The [NodeJS 10 standard library](https://nodejs.org/dist/latest-v10.x/docs/api/) is available to use within your plugin. To receive game events in your plugin, you must subscribe to events from `proxy`. See the See the [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) for the two options to receive events - every game event, or subscribe to specific events. `proxy` is an [EventEmitter](https://nodejs.org/docs/latest-v10.x/api/events.html). `config` is the configuration for the full SW-Exporter application. You can access your specific plugin's configuration like this: `config.Config.Plugins[<pluginName>]`. When in doubt, browse through the [prepackaged plugins](https://github.com/Xzandro/sw-exporter/tree/external-plugins/app/plugins) for examples.
+
+### Single Javascript File
+
+The [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) is a fully featured plugin with no dependencies on external libraries.
+
+### Full NPM package
+
+See this [example repo](https://github.com/PeteAndersen/example-swex-plugin) for a plugin that requires the [request](https://github.com/request/request) module as a dependency to do something. As long as your package's default export matches the form specified above, you can do anything you like within your package.
+
+#### Packaging
+
+You can place your plugin as a folder of files in the `plugins` directory and it will work. However, it is recommended for distribution to package your plugin as an [asar](https://github.com/electron/asar) file so your users do not have to deal with the high number of individual files inherent to javascript applications.
+
+To correctly package your plugin, run `$ asar pack <plugin-folder-name> <plugin-name>.asar`. Your asar archive should include all of your javascript code files and a `node_modules` folder with your dependencies.
+
+### Installing Plugins
+
+Place your plugin in the `Summoners War Exporter Files\plugins` directory. The full path of this folder is found in the game settings. SW-Exporter will attempt to load all plugins in this folder on startup and run your `init()` function.
+
+## Developing SW-Exporter
+
 Install [node.js](https://nodejs.org/).
+
 ```
 $ git clone https://github.com/Xzandro/sw-exporter.git
 $ cd sw-exporter
@@ -24,13 +67,17 @@ $ npm start
 And you are ready to develop. We use ESLint for linting so make sure there are no linting errors before you submit a PR please.
 
 ## Building Packages
+
 At first you need to keep in mind that you can only build packages for your current used OS!
 
 It is also important that the bundle.js is generated & update-to-date. You can accomplish that via
+
 ```
 $ npm run dev
 ```
+
 to start the Development script or just do
+
 ```
 $ webpack
 ```
@@ -38,7 +85,9 @@ $ webpack
 After that you have several possibilities.
 
 ### Windows
+
 For Windows you can build a Portable or Setup version (default: Setup). That's changeable via the package.json.
+
 ```
 "win": {
   "target": [
@@ -46,27 +95,34 @@ For Windows you can build a Portable or Setup version (default: Setup). That's c
   ]
 }
 ```
+
 Just change nsis to portable.
 
 Building the packages
+
 ```
 $ npm run dist:win32
 $ npm run dist:win64
 ```
 
 ### Linux
+
 An AppImage package file will be build which is compatible with most common linux os.
+
 ```
 $ npm run dist:linux
 ```
 
 ### Mac
+
 A typical DMG package file will be build.
+
 ```
 $ npm run dist:mac
 ```
 
 ## Setting up on a VPS
+
 Basically the same like for the Development environment, but you need to set two process enrionment variables:
 
 1. port (set this to your liking)

--- a/README.md
+++ b/README.md
@@ -32,25 +32,32 @@ module.exports = {
 }
 ```
 
-The [NodeJS 10 standard library](https://nodejs.org/dist/latest-v10.x/docs/api/) is available to use within your plugin. To receive game events in your plugin, you must subscribe to events from `proxy`. See the See the [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) for the two options to receive events - every game event, or subscribe to specific events. `proxy` is an [EventEmitter](https://nodejs.org/docs/latest-v10.x/api/events.html). `config` is the configuration for the full SW-Exporter application. You can access your specific plugin's configuration like this: `config.Config.Plugins[<pluginName>]`. When in doubt, browse through the [prepackaged plugins](https://github.com/Xzandro/sw-exporter/tree/external-plugins/app/plugins) for examples.
+The [NodeJS 10 standard library](https://nodejs.org/dist/latest-v10.x/docs/api/) is available to use within your plugin. To receive game events, you must subscribe to events from `proxy`. See the See the [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) for the two options to receive events - every game event, or specific events. `proxy` is an [EventEmitter](https://nodejs.org/docs/latest-v10.x/api/events.html). `config` is the configuration for the full SW-Exporter application. You can access your specific plugin's configuration like this: `config.Config.Plugins[<pluginName>]`. When in doubt, browse through the [prepackaged plugins](https://github.com/Xzandro/sw-exporter/tree/external-plugins/app/plugins) for examples.
 
 ### Single Javascript File
 
-The [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) is a fully featured plugin with no dependencies on external libraries.
+The [example plugin](https://github.com/Xzandro/sw-exporter/blob/external-plugins/app/plugins/example-plugin.js) details a barebones plugin with no external dependencies.
 
 ### Full NPM package
 
-See this [example repo](https://github.com/PeteAndersen/example-swex-plugin) for a plugin that requires the [request](https://github.com/request/request) module as a dependency to do something. As long as your package's default export matches the form specified above, you can do anything you like within your package.
+See this [example repo](https://github.com/PeteAndersen/example-swex-plugin) for a plugin that requires the [request](https://github.com/request/request) module as a dependency to do something. As long as your package's default export matches the form specified above, you can do anything you like within your package, including external dependencies. These dependencies must be in a node_modules folder within your plugin directory. The full file structure would look something like this:
+
+```
+> Summoners War Exporter Files\plugins\my-fancy-plugin
+> Summoners War Exporter Files\plugins\my-fancy-plugin\index.js
+> Summoners War Exporter Files\plugins\my-fancy-plugin\other-plugin-code.js
+> Summoners War Exporter Files\plugins\my-fancy-plugin\node_modules
+```
 
 #### Packaging
 
-You can place your plugin as a folder of files in the `plugins` directory and it will work. However, it is recommended for distribution to package your plugin as an [asar](https://github.com/electron/asar) file so your users do not have to deal with the high number of individual files inherent to javascript applications.
+You can place your plugin as a folder of files in the `plugins` directory and it will work. However, it is recommended for distribution to package your plugin as an [asar](https://github.com/electron/asar) file.
 
-To correctly package your plugin, run `$ asar pack <plugin-folder-name> <plugin-name>.asar`. Your asar archive should include all of your javascript code files and a `node_modules` folder with your dependencies.
+To correctly package your plugin, run `$ asar pack <plugin-folder-name> <plugin-name>.asar`. Your asar archive should include all of your javascript code files and a `node_modules` folder with your dependencies. To install your packaged plugin, simply drop the plugin.asar into the plugins folder. The directory structure will look like this:
 
-### Installing Plugins
-
-Place your plugin in the `Summoners War Exporter Files\plugins` directory. The full path of this folder is found in the game settings. SW-Exporter will attempt to load all plugins in this folder on startup and run your `init()` function.
+```
+Summoners War Exporter Files\plugins\my-fancy-plugin.asar
+```
 
 ## Developing SW-Exporter
 

--- a/app/main.js
+++ b/app/main.js
@@ -94,8 +94,7 @@ ipcMain.on('updateConfig', () => {
 
 ipcMain.on('getFolderLocations', event => {
   event.returnValue = {
-    settings: app.getPath('userData'),
-    plugins: path.join(path.dirname(app.getPath('exe')), 'plugins')
+    settings: app.getPath('userData')
   };
 });
 
@@ -105,11 +104,13 @@ function loadPlugins() {
   // Initialize Plugins
   let plugins = [];
 
-  const pluginDir = path.join(__dirname, 'plugins');
+  const pluginDirs = [path.join(__dirname, 'plugins'), path.join(global.config.Config.App.filesPath, 'plugins')];
 
   // Load each plugin module in the folder
-  fs.readdirSync(pluginDir).forEach(file => {
-    plugins.push(require(path.join(pluginDir, file)));
+  pluginDirs.forEach(dir => {
+    fs.readdirSync(dir).forEach(file => {
+      plugins.push(require(path.join(dir, file)));
+    });
   });
 
   // Initialize plugins


### PR DESCRIPTION
Added capability to load plugins from the data output folder. Plugins must be CommonJS modules and can either be single javascript files or NPM packages with their own dependencies. Plugins can be packaged into asar files for ease of distribution. 