### PR TITLE
Performance improvements for the log section

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -14,14 +14,18 @@ global.appVersion = app.getVersion();
 let defaultFilePath = path.join(app.getPath('desktop'), `${app.getName()} Files`);
 let defaultConfig = {
   Config: {
-    App: { filesPath: defaultFilePath, debug: false, clearLogOnLogin: false },
+    App: { filesPath: defaultFilePath, debug: false, clearLogOnLogin: false, maxLogEntries: 100 },
     Proxy: { port: 8080, autoStart: false },
     Plugins: {}
   }
 };
 let defaultConfigDetails = {
   ConfigDetails: {
-    App: { debug: { label: 'Show Debug Messages' }, clearLogOnLogin: { label: 'Clear Log on every login' } },
+    App: {
+      debug: { label: 'Show Debug Messages' },
+      clearLogOnLogin: { label: 'Clear Log on every login' },
+      maxLogEntries: { label: 'Maximum amount of log entries.' }
+    },
     Proxy: { autoStart: { label: 'Start proxy automatically' } },
     Plugins: {}
   }

--- a/app/mapping.js
+++ b/app/mapping.js
@@ -871,6 +871,9 @@ module.exports = {
       22914: 'Emily',
       22915: 'Bella',
 
+      23005: 'Vampire Lord',
+      23015: 'Eirgar',
+
       15105: 'Devilmon',
       14314: 'Rainbowmon',
 

--- a/app/pages/Logs.js
+++ b/app/pages/Logs.js
@@ -53,10 +53,10 @@ class Logs extends React.Component {
   }
 
   render() {
-    const LogEntries = this.state.entries.map((entry, i) => {
+    const LogEntries = this.state.entries.map(entry => {
       if (entry.type !== 'debug' || config.Config.App.debug) {
         return (
-          <Feed key={i} className="log" size="small">
+          <Feed key={entry.id} className="log" size="small">
             <Feed.Event>
               <Feed.Content>
                 <Feed.Summary>

--- a/app/pages/Settings.js
+++ b/app/pages/Settings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, Checkbox, Grid, Header, Form, Icon, Popup, Segment } from 'semantic-ui-react';
+import { Button, Checkbox, Grid, Header, Input, Form, Icon, Popup, Segment } from 'semantic-ui-react';
 import SettingsPlugin from '../components/SettingsPlugin';
 import SettingsItem from '../components/SettingsItem';
 
@@ -75,6 +75,7 @@ class Settings extends React.Component {
             </Form.Group>
             <Form.Group widths={2}>
               <SettingsItem section="App" setting="clearLogOnLogin" Input={<Checkbox />} />
+              <SettingsItem section="App" setting="maxLogEntries" Input={<Input />} />
             </Form.Group>
           </Form>
         </Segment>

--- a/app/proxy/SWProxy.js
+++ b/app/proxy/SWProxy.js
@@ -4,6 +4,7 @@ const httpProxy = require('http-proxy');
 const os = require('os');
 const net = require('net');
 const url = require('url');
+const uuidv4 = require('uuid/v4');
 
 const { decrypt_request, decrypt_response } = require('./smon_decryptor');
 
@@ -114,15 +115,11 @@ class SWProxy extends EventEmitter {
     this.httpServer.on('connect', (req, socket) => {
       const serverUrl = url.parse(`https://${req.url}`);
 
-      const srvSocket = net.connect(
-        serverUrl.port,
-        serverUrl.hostname,
-        () => {
-          socket.write('HTTP/1.1 200 Connection Established\r\n' + 'Proxy-agent: Node-Proxy\r\n' + '\r\n');
-          srvSocket.pipe(socket);
-          socket.pipe(srvSocket);
-        }
-      );
+      const srvSocket = net.connect(serverUrl.port, serverUrl.hostname, () => {
+        socket.write('HTTP/1.1 200 Connection Established\r\n' + 'Proxy-agent: Node-Proxy\r\n' + '\r\n');
+        srvSocket.pipe(socket);
+        socket.pipe(srvSocket);
+      });
 
       srvSocket.on('error', () => {});
 
@@ -164,8 +161,16 @@ class SWProxy extends EventEmitter {
       return;
     }
 
+    // add unique id for performance reasons
+    entry.id = uuidv4();
+
     entry.date = new Date().toLocaleTimeString();
     this.logEntries = [entry, ...this.logEntries];
+
+    const maxLogEntries = parseInt(config.Config.App.maxLogEntries);
+    if (this.logEntries.length > maxLogEntries && maxLogEntries !== 0) {
+      this.logEntries.pop();
+    }
 
     win.webContents.send('logupdated', this.logEntries);
   }

--- a/app/proxy/SWProxy.js
+++ b/app/proxy/SWProxy.js
@@ -167,7 +167,7 @@ class SWProxy extends EventEmitter {
     entry.date = new Date().toLocaleTimeString();
     this.logEntries = [entry, ...this.logEntries];
 
-    const maxLogEntries = parseInt(config.Config.App.maxLogEntries);
+    const maxLogEntries = parseInt(config.Config.App.maxLogEntries) || 0;
     if (this.logEntries.length > maxLogEntries && maxLogEntries !== 0) {
       this.logEntries.pop();
     }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-router-dom": "^5.0.0",
     "request": "^2.88.0",
     "sanitize-filename": "^1.6.1",
-    "semantic-ui-react": "^0.87.1"
+    "semantic-ui-react": "^0.87.1",
+    "uuid": "^3.3.2"
   }
 }


### PR DESCRIPTION
To improve performance we probably should restrict the max amount of log entries, since it's rarely used anyway. I decided to set the default max amount to 100.

I also set a unique id to each entry so react can better to the shadow DOM magic, instead of using just the .map() index for the key property, which should further improve performance.