### PR TITLE
Added the Application User Model Id

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -166,6 +166,7 @@ function loadPlugins() {
 }
 
 app.on('ready', () => {
+  app.setAppUserModelId(process.execPath);
   createWindow();
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
Added the application user model id to the app to allow notifications on Windows. This will also fix chinleung/sw-exporter-run-notifier#1 for the plugin.

Source: https://electronjs.org/docs/tutorial/notifications#windows