### PR TITLE
Show after reApp efficiency before making your reApp selection.

### DIFF
--- a/app/plugins/rune-drop-efficiency.js
+++ b/app/plugins/rune-drop-efficiency.js
@@ -95,6 +95,8 @@ module.exports = {
           });
         }
         break;
+      case 'RevalueRune':
+        runesInfo.push(this.logRuneDrop(resp.rune))
 
       default:
         break;


### PR DESCRIPTION
This will log the rune efficiency of the new stats when initiating a reappraisal, before selecting the stat set to keep.