### PR TITLE
Fix column number mismatch in elemental rift raid logging.

### DIFF
--- a/app/plugins/run-logger.js
+++ b/app/plugins/run-logger.js
@@ -445,8 +445,8 @@ module.exports = {
       });
     }
 
-    if (resp.unit_list && resp.unit_list.length > 0) {
-      resp.unit_list.forEach((unit, i) => {
+    if (resp.my_unit_deck_list && resp.my_unit_deck_list.length > 0) {
+      resp.my_unit_deck_list.forEach((unit, i) => {
         entry[`team${i + 1}`] = gMapping.getMonsterName(unit.unit_master_id);
       });
     }


### PR DESCRIPTION
Fix for issue #333 

The elemental rift raid response has a different wrapper name for the monster array (my_unit_deck_list instead of unit_list), which meant the monster columns weren't added to the row, creating a mismatch. (For other reasons, the monster names aren't added, but that's because they are not in the request so not available to log.)

Ran this through 50 runs and about 20 regular rift runs without problems, but of course it would be helpful if others checked too.