### PR TITLE
Fix battles run mappings in chaos dungeons

### DIFF
--- a/app/mapping.js
+++ b/app/mapping.js
@@ -1896,7 +1896,7 @@ module.exports = {
     9501: 'Steel Fortress',
     9502: `Punisher's Crypt`,
     9503: `Spiritual Realm`,
-    9513: `Spiritual Realm Abyss`
+    9513: `Spiritual Realm Abyss`,
   },
   elemental_rift_dungeon: {
     1001: 'Rift Dungeon - Ice Beast',

--- a/app/mapping.js
+++ b/app/mapping.js
@@ -1887,12 +1887,16 @@ module.exports = {
     4001: 'Hall of Wind',
     5001: 'Hall of Magic',
     6001: 'Necropolis',
+    6011: 'Necropolis Abyss',
     7001: 'Hall of Light',
     8001: `Giant's Keep`,
+    8011: `Giant's Keep Abyss`,
     9001: `Dragon's Lair`,
+    9011: `Dragon's Lair Abyss`,
     9501: 'Steel Fortress',
     9502: `Punisher's Crypt`,
-    9502: `Spiritual Realm`,
+    9503: `Spiritual Realm`,
+    9513: `Spiritual Realm Abyss`
   },
   elemental_rift_dungeon: {
     1001: 'Rift Dungeon - Ice Beast',


### PR DESCRIPTION
There are issues in Battle log runs. In this exemple I did Giant AH, Dragon AH, Necro AH, Spirit AH, Steel Fortress B10 and Punisher B10 :

```
2023-11-11 12:02,Unknown,Win,1:05,11304,0,0,Rune,6*,13801,Swift,48.21,5,Rare,HP +360,,SPD +6,ATK 6%,,,Akhamamir,Savannah,Galleon,Veromos,Laika
2023-11-11 12:04,Unknown,Win,1:27,11366,0,0,Rune Piece x12,,,,,,,,,,,,,Verdehile,Veromos,Poseidon,Loren,Spectra
2023-11-11 12:07,Unknown,Win,1:44,10710,0,6,Symbol of Chaos x8,,,,,,,,,,,,,Abigail,Raoq,Icaru,Astar,Shamann
2023-11-11 12:09,Unknown,Win,1:46,10428,0,0,Unknown Drop,,,,,,,,,,,,,High Elemental (Fire),Raoq,Randy,Spectra,Shaina
2023-11-11 12:10,Steel Fortress B10,Win,0:44,11160,0,2,Artifact,,,Attribute (Fire),,,Hero,DEF +100,,Damage Received from Water -5%,Additional Damage by 7% of DEF,SPD Increasing Effect +10%,Damage Received from Fire -4%,Sath,Raoq,Mellia,Mellia,Tatu
2023-11-11 12:12,Spiritual Realm B10,Win,1:01,12034,0,2,Artifact,,,Archetype (Support),,,Rare,HP +1500,,Single-target skill CRIT DMG 11% on your turn,Life Drain +6%,Skill 2 Recovery +6%,SPD Increasing Effect +5%,Verdehile,Icaru,Raoq,Kro,Eirgar
```

As you can see, mappings are wrong. I've checked full_logs to get correct ids and I correct mapping.js.
For Abyss dungeons, It will be displayed "`<dungeon name>` Abyss B`<stage>`" where stage is 1 or 2.