### PR TITLE
SWOP formula in rune-efficiency plugin

### DIFF
--- a/app/plugins/rune-drop-efficiency.js
+++ b/app/plugins/rune-drop-efficiency.js
@@ -1,6 +1,10 @@
 module.exports = {
   defaultConfig: {
     enabled: true,
+    SWOPformula: false,
+  },
+  defaultConfigDetails: {
+    SWOPformula: { label: 'Flat stat at half value' },
   },
   pluginName: 'RuneDropEfficiency',
   pluginDescription: 'Logs the maximum possible efficiency for runes as they drop.',
@@ -127,9 +131,32 @@ module.exports = {
       });
     }
   },
+  
+  halveFlats(rune) {
+    const flatStats = [1, 3, 5];
+
+    // sub stats
+    rune.sec_eff.forEach((stat) => {
+      if (flatStats.includes(stat[0])) {
+        stat[1] *= 0.5;
+        if (stat[3] && stat[3] > 0) {
+          stat[3] *= 0.5;
+        }
+      }
+    });
+
+    // innate stat
+    if (flatStats.includes(rune.prefix_eff[0])) {
+      rune.prefix_eff[1] *= 0.5;
+    }
+
+    return rune;
+  },
 
   logRuneDrop(rune) {
-    const efficiency = gMapping.getRuneEfficiency(rune);
+    const efficiency = config.Config.Plugins[this.pluginName].SWOPformula
+      ? gMapping.getRuneEfficiency(this.halveFlats(rune))
+      : gMapping.getRuneEfficiency(rune);
     const runeQuality = gMapping.rune.quality[rune.rank];
     const colorTable = {
       Common: 'grey',

--- a/app/plugins/rune-drop-efficiency.js
+++ b/app/plugins/rune-drop-efficiency.js
@@ -131,7 +131,7 @@ module.exports = {
       });
     }
   },
-  
+
   halveFlats(rune) {
     const flatStats = [1, 3, 5];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sw-exporter",
-  "version": "0.0.58",
+  "version": "0.0.62",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sw-exporter",
-      "version": "0.0.58",
+      "version": "0.0.62",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/remote": "^2.0.1",


### PR DESCRIPTION
Followed the discusion of pr#493, seems inactive:
https://github.com/Xzandro/sw-exporter/pull/493#issuecomment-1679880471

Added SWOP setting and halveFlats() in rune-efficiency plugins.
Logic of lines 142,143 to review.
Can brick existing external plugin.